### PR TITLE
Fix stale imports and warnings after deps update

### DIFF
--- a/src/bin/audio_udp.rs
+++ b/src/bin/audio_udp.rs
@@ -8,10 +8,7 @@ use embassy_executor::Executor;
 use embassy_executor::Spawner;
 use embassy_net::udp::{PacketMetadata, UdpSocket};
 use embassy_net::{IpAddress, IpEndpoint};
-use embassy_rp::adc::InterruptHandler as ADCInterruptHandler;
-use embassy_rp::bind_interrupts;
 use embassy_rp::multicore::{spawn_core1, Stack};
-use embassy_rp::peripherals::{ADC, DMA_CH0, PIN_26};
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::channel::Channel as SyncChannel;
 use embassy_sync::mutex::Mutex;
@@ -25,7 +22,6 @@ use {defmt_rtt as _, panic_probe as _};
 
 // ---------- Executors / Core stacks ----------
 static mut CORE1_STACK: Stack<4096> = Stack::new();
-static EXECUTOR0: StaticCell<Executor> = StaticCell::new();
 static EXECUTOR1: StaticCell<Executor> = StaticCell::new();
 
 // ---------- Audio channel ----------
@@ -51,7 +47,7 @@ async fn main(spawner: Spawner) {
     );
 
     // ---------- Core0: Connect Wi-Fi asynchronously ----------
-    let mut embassy_pico_wifi_core = EmbassyPicoWifiCore::connect_to_network(
+    let embassy_pico_wifi_core = EmbassyPicoWifiCore::connect_to_network(
         p.PIN_23,
         p.PIN_24,
         p.PIN_25,

--- a/src/bin/audio_usb.rs
+++ b/src/bin/audio_usb.rs
@@ -5,12 +5,9 @@
 
 use defmt::*;
 use embassy_executor::Executor;
-use embassy_rp::adc::InterruptHandler as ADCInterruptHandler;
-use embassy_rp::bind_interrupts;
 use embassy_rp::multicore::{Stack, spawn_core1};
 use embassy_rp::peripherals::USB;
-use embassy_rp::time_driver::init;
-use embassy_rp::usb::{Driver, InterruptHandler as USBInterruptHandler};
+use embassy_rp::usb::Driver;
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::channel::Channel as SyncChannel;
 use embassy_usb::class::cdc_acm::{CdcAcmClass, State as CdcState};

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -16,9 +16,7 @@ use picoserve::extract::State;
 use pinot_voir::common::dht22_tools::DHT22;
 use pinot_voir::common::sensor_tools::SensorState;
 use pinot_voir::common::shared_functions::{EnvironmentVariables, blink_n_times};
-use pinot_voir::common::wifi::{
-    EmbassyPicoWifiCore, SharedEmbassyWifiPicoCore, WEB_TASK_POOL_SIZE, wifi_autoheal_task,
-};
+use pinot_voir::common::wifi::{EmbassyPicoWifiCore, SharedEmbassyWifiPicoCore, WEB_TASK_POOL_SIZE};
 
 use picoserve::{
     AppRouter, AppWithStateBuilder,

--- a/src/common/usb.rs
+++ b/src/common/usb.rs
@@ -45,7 +45,7 @@ pub async fn write_cdc_chunked(
 pub fn init_usb(usb: Peri<'static, USB>) -> embassy_usb::Builder<'static, Driver<'static, USB>> {
     let driver = Driver::new(usb, Irqs);
 
-    let mut usb_builder = embassy_usb::Builder::new(
+    let usb_builder = embassy_usb::Builder::new(
         driver,
         {
             let mut cfg = embassy_usb::Config::new(0xc0de, 0xcafe);


### PR DESCRIPTION
Remove unused imports and dead code left over from the dependency
update: ADC interrupt handlers, bind_interrupts, time_driver::init,
and unused peripherals imports that are no longer needed after
the audio modules were refactored into common/. Also remove the
unused wifi_autoheal_task import from server.rs (disabled in previous
commit) and drop unnecessary mut qualifiers.

https://claude.ai/code/session_017MP4hbbrcDJ8JXW76YBivA