### PR TITLE
Fix all bin APIs after dependency update

### DIFF
--- a/src/bin/audio_udp.rs
+++ b/src/bin/audio_udp.rs
@@ -8,36 +8,28 @@ use embassy_executor::Executor;
 use embassy_executor::Spawner;
 use embassy_net::udp::{PacketMetadata, UdpSocket};
 use embassy_net::{IpAddress, IpEndpoint};
-use embassy_rp::adc::InterruptHandler as ADCInterruptHandler;
-use embassy_rp::bind_interrupts;
 use embassy_rp::dma;
 use embassy_rp::multicore::{spawn_core1, Stack};
-use embassy_rp::peripherals::{ADC, DMA_CH0, DMA_CH1, PIN_26};
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::channel::Channel as SyncChannel;
 use embassy_sync::mutex::Mutex;
 use embassy_time::{Duration, Instant, Timer};
 use pinot_voir::common::adc_microphone::{adc_task, AudioBlock, AUDIO_BUFFER_SIZE};
 use pinot_voir::common::shared_functions::EnvironmentVariables;
-use pinot_voir::common::wifi::{EmbassyPicoWifiCore, SharedEmbassyWifiPicoCore};
+use pinot_voir::common::wifi::{EmbassyPicoWifiCore, Irqs, SharedEmbassyWifiPicoCore};
 use static_cell::StaticCell;
-
-bind_interrupts!(struct AudioIrqs {
-    DMA_IRQ_0 => dma::InterruptHandler<DMA_CH1>;
-});
-
-static WIFI_CORE: StaticCell<Mutex<CriticalSectionRawMutex, pinot_voir::common::wifi::EmbassyPicoWifiCore>> = StaticCell::new();
 use {defmt_rtt as _, panic_probe as _};
 
 // ---------- Executors / Core stacks ----------
 static mut CORE1_STACK: Stack<4096> = Stack::new();
-static EXECUTOR0: StaticCell<Executor> = StaticCell::new();
 static EXECUTOR1: StaticCell<Executor> = StaticCell::new();
 
 // ---------- Audio channel ----------
 static AUDIO_CHANNEL: SyncChannel<CriticalSectionRawMutex, AudioBlock, 4> = SyncChannel::new();
 
 static ENV: StaticCell<EnvironmentVariables> = StaticCell::new();
+static WIFI_CORE: StaticCell<Mutex<CriticalSectionRawMutex, EmbassyPicoWifiCore>> =
+    StaticCell::new();
 
 #[embassy_executor::main]
 async fn main(spawner: Spawner) {
@@ -53,13 +45,21 @@ async fn main(spawner: Spawner) {
         move || {
             let executor1 = EXECUTOR1.init(Executor::new());
             executor1.run(|spawner| {
-                unwrap!(spawner.spawn(adc_task(&AUDIO_CHANNEL, p.ADC, p.DMA_CH1, p.PIN_26)));
+                spawner.spawn(
+                    adc_task(
+                        &AUDIO_CHANNEL,
+                        p.ADC,
+                        dma::Channel::new(p.DMA_CH1, Irqs),
+                        p.PIN_26,
+                    )
+                    .unwrap(),
+                );
             });
         },
     );
 
     // ---------- Core0: Connect Wi-Fi asynchronously ----------
-    let mut embassy_pico_wifi_core = EmbassyPicoWifiCore::connect_to_network(
+    let embassy_pico_wifi_core = EmbassyPicoWifiCore::connect_to_network(
         p.PIN_23,
         p.PIN_24,
         p.PIN_25,
@@ -72,17 +72,14 @@ async fn main(spawner: Spawner) {
     .await;
 
     let shared_wifi_core: SharedEmbassyWifiPicoCore =
-        SharedEmbassyWifiPicoCore(make_static!(Mutex::new(embassy_pico_wifi_core)));
+        SharedEmbassyWifiPicoCore(WIFI_CORE.init(Mutex::new(embassy_pico_wifi_core)));
 
     // ---------- Spawn UDP task ----------
     let target_ip = IpAddress::v4(255, 255, 255, 255);
     let port = 1234;
-    unwrap!(spawner.spawn(udp_tx_task(
-        &AUDIO_CHANNEL,
-        shared_wifi_core,
-        target_ip,
-        port,
-    )));
+    spawner.spawn(
+        udp_tx_task(&AUDIO_CHANNEL, shared_wifi_core, target_ip, port).unwrap(),
+    );
 }
 
 /// Task running on Core0: reads AudioBlocks and sends via UDP with proper rate limiting
@@ -111,31 +108,32 @@ async fn udp_tx_task(
     let mut stats_timer = Instant::now();
     let mut blocks_ok = 0u32;
     let mut blocks_err = 0u32;
-    
+
     // Calculate the exact timing for each audio block
     // 512 samples at 44100 Hz = 11.61ms per block
     const SAMPLE_RATE_HZ: u32 = 44100;
-    const BLOCK_DURATION_MICROS: u64 = (AUDIO_BUFFER_SIZE as u64 * 1_000_000) / SAMPLE_RATE_HZ as u64;
-    
+    const BLOCK_DURATION_MICROS: u64 =
+        (AUDIO_BUFFER_SIZE as u64 * 1_000_000) / SAMPLE_RATE_HZ as u64;
+
     info!("UDP task: Block duration = {} microseconds", BLOCK_DURATION_MICROS);
 
     loop {
         let send_start = Instant::now();
-        
+
         // Get the latest block, dropping any that have queued up
         let mut block: AudioBlock = audio_channel.receive().await;
         let mut dropped_count = 0;
-        
+
         // Drop excess blocks to maintain real-time performance
         while let Ok(newer_block) = audio_channel.try_receive() {
             block = newer_block;
             dropped_count += 1;
         }
-        
+
         if dropped_count > 0 {
             info!("Dropped {} audio blocks to maintain real-time", dropped_count);
         }
-        
+
         let samples = block.centre_samples();
         let bytes: &[u8] = bytemuck::cast_slice(&samples);
 
@@ -150,14 +148,17 @@ async fn udp_tx_task(
 
         // Calculate how long we spent processing and sending
         let processing_time = send_start.elapsed();
-        
+
         // Wait for the remainder of the block period
         if processing_time.as_micros() < BLOCK_DURATION_MICROS {
             let wait_time = BLOCK_DURATION_MICROS - processing_time.as_micros();
             Timer::after_micros(wait_time).await;
         } else {
-            // If processing took longer than expected, log a warning but don't wait
-            info!("Processing took {}μs, expected {}μs", processing_time.as_micros(), BLOCK_DURATION_MICROS);
+            info!(
+                "Processing took {}μs, expected {}μs",
+                processing_time.as_micros(),
+                BLOCK_DURATION_MICROS
+            );
         }
 
         // Stats reporting
@@ -169,7 +170,7 @@ async fn udp_tx_task(
                 (blocks_ok as f32 / total as f32) * 100.0
             };
             info!(
-                "UDP Stats: {} ok, {} err ({}% ok), last processing time: {}μs", 
+                "UDP Stats: {} ok, {} err ({}% ok), last processing time: {}μs",
                 blocks_ok,
                 blocks_err,
                 pct,

--- a/src/bin/audio_usb.rs
+++ b/src/bin/audio_usb.rs
@@ -5,17 +5,16 @@
 
 use defmt::*;
 use embassy_executor::Executor;
-use embassy_rp::adc::InterruptHandler as ADCInterruptHandler;
-use embassy_rp::bind_interrupts;
+use embassy_rp::dma;
 use embassy_rp::multicore::{Stack, spawn_core1};
 use embassy_rp::peripherals::USB;
-use embassy_rp::time_driver::init;
-use embassy_rp::usb::{Driver, InterruptHandler as USBInterruptHandler};
+use embassy_rp::usb::Driver;
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::channel::Channel as SyncChannel;
 use embassy_usb::class::cdc_acm::{CdcAcmClass, State as CdcState};
 use pinot_voir::common::adc_microphone::{AudioBlock, adc_task};
 use pinot_voir::common::usb::{cdc_tx_task, init_usb, usb_device_task};
+use pinot_voir::common::wifi::Irqs;
 use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};
 
@@ -43,7 +42,15 @@ fn main() -> ! {
         move || {
             let executor1 = EXECUTOR1.init(Executor::new());
             executor1.run(|spawner| {
-                unwrap!(spawner.spawn(adc_task(&AUDIO_CHANNEL, p.ADC, p.DMA_CH1, p.PIN_26)));
+                spawner.spawn(
+                    adc_task(
+                        &AUDIO_CHANNEL,
+                        p.ADC,
+                        dma::Channel::new(p.DMA_CH1, Irqs),
+                        p.PIN_26,
+                    )
+                    .unwrap(),
+                );
             });
         },
     );
@@ -56,13 +63,12 @@ fn main() -> ! {
         let cdc = CDC_CLASS.init(CdcAcmClass::new(
             &mut usb_builder,
             CDC_STATE.init(CdcState::new()),
-            MAX_USB_BUF as u16, // max_packet_size for CDC EP
+            MAX_USB_BUF as u16,
         ));
 
         let usb = usb_builder.build();
 
-        // Run USB device + CDC TX task
-        unwrap!(spawner.spawn(usb_device_task(usb)));
-        unwrap!(spawner.spawn(cdc_tx_task(&AUDIO_CHANNEL, cdc)));
+        spawner.spawn(usb_device_task(usb).unwrap());
+        spawner.spawn(cdc_tx_task(&AUDIO_CHANNEL, cdc).unwrap());
     });
 }

--- a/src/bin/blink.rs
+++ b/src/bin/blink.rs
@@ -2,28 +2,13 @@
 #![no_std]
 #![no_main]
 
-use cyw43_pio::PioSpi;
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_rp::bind_interrupts;
 use embassy_rp::gpio::{Level, Output};
-use embassy_rp::peripherals::{DMA_CH0, PIO0};
-use embassy_rp::pio::InterruptHandler;
 use embassy_sync::blocking_mutex::raw::ThreadModeRawMutex;
 use embassy_sync::channel::{Channel, Sender};
 use embassy_time::{Duration, Ticker};
 use {defmt_rtt as _, panic_probe as _};
-
-bind_interrupts!(struct Irqs {
-    PIO0_IRQ_0 => InterruptHandler<PIO0>;
-});
-
-#[embassy_executor::task]
-async fn cyw43_task(
-    runner: cyw43::Runner<'static, Output<'static>, PioSpi<'static, PIO0, 0, DMA_CH0>>,
-) -> ! {
-    runner.run().await
-}
 
 enum LedState {
     Toggle,
@@ -39,11 +24,14 @@ async fn main(spawner: Spawner) {
     let dt = 100 * 1_000_000;
     let k = 1.003;
 
-    unwrap!(spawner.spawn(toggle_led(CHANNEL.sender(), Duration::from_nanos(dt))));
-    unwrap!(spawner.spawn(toggle_led(
-        CHANNEL.sender(),
-        Duration::from_nanos((dt as f64 * k) as u64)
-    )));
+    spawner.spawn(toggle_led(CHANNEL.sender(), Duration::from_nanos(dt)).unwrap());
+    spawner.spawn(
+        toggle_led(
+            CHANNEL.sender(),
+            Duration::from_nanos((dt as f64 * k) as u64),
+        )
+        .unwrap(),
+    );
 
     loop {
         match CHANNEL.receive().await {

--- a/src/bin/read_dht22.rs
+++ b/src/bin/read_dht22.rs
@@ -1,28 +1,10 @@
 #![no_std]
 #![no_main]
 
-use cyw43_pio::PioSpi;
 use embassy_dht::dht22::DHT22;
-
 use embassy_executor::Spawner;
-use embassy_rp::bind_interrupts;
-use embassy_rp::gpio::Output;
-use embassy_rp::peripherals::{DMA_CH0, PIO0};
-
-use embassy_rp::pio::InterruptHandler;
 use embassy_time::{Delay, Duration, Timer};
 use {defmt_rtt as _, panic_probe as _};
-
-bind_interrupts!(struct Irqs {
-    PIO0_IRQ_0 => InterruptHandler<PIO0>;
-});
-
-#[embassy_executor::task]
-async fn cyw43_task(
-    runner: cyw43::Runner<'static, Output<'static>, PioSpi<'static, PIO0, 0, DMA_CH0>>,
-) -> ! {
-    runner.run().await
-}
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {

--- a/src/bin/supabase.rs
+++ b/src/bin/supabase.rs
@@ -19,14 +19,16 @@ use pinot_voir::common::wifi::{EmbassyPicoWifiCore, HttpBuffers};
 use reqwless::client::{HttpClient, HttpConnection, TlsConfig, TlsVerify};
 use reqwless::request::{Method, RequestBuilder};
 use reqwless::response::Response;
-use static_cell::make_static;
+use static_cell::StaticCell;
 
 use {defmt_rtt as _, panic_probe as _};
+
+static ENV: StaticCell<EnvironmentVariables> = StaticCell::new();
 
 #[embassy_executor::main]
 async fn main(spawner: Spawner) {
     let environment_variables: &'static EnvironmentVariables =
-        make_static!(EnvironmentVariables::new());
+        ENV.init(EnvironmentVariables::new());
     let p = embassy_rp::init(Default::default());
     // Wifi prelude
     info!("Hello World!");

--- a/src/bin/uart_log.rs
+++ b/src/bin/uart_log.rs
@@ -7,8 +7,9 @@ use defmt::info;
 use embassy_executor::Spawner;
 use embassy_rp::adc::{Adc, Channel, Config, InterruptHandler as ADCInterruptHandler};
 use embassy_rp::bind_interrupts;
+use embassy_rp::dma;
 use embassy_rp::gpio::Pull;
-use embassy_rp::peripherals::USB;
+use embassy_rp::peripherals::{DMA_CH0, USB};
 use embassy_rp::usb::{Driver, InterruptHandler as USBInterruptHandler};
 use embassy_usb::UsbDevice;
 use embassy_usb::class::cdc_acm::{CdcAcmClass, State};
@@ -22,6 +23,9 @@ bind_interrupts!(struct Irqs {
 bind_interrupts!(struct IrqsADC {
     ADC_IRQ_FIFO => ADCInterruptHandler;
 });
+bind_interrupts!(struct IrqsDMA {
+    DMA_IRQ_0 => dma::InterruptHandler<DMA_CH0>;
+});
 
 async fn write_cdc_chunked<'a>(
     cdc: &mut CdcAcmClass<'static, Driver<'static, USB>>,
@@ -32,16 +36,10 @@ async fn write_cdc_chunked<'a>(
     while offset < data.len() {
         let end = (offset + max_packet_size).min(data.len());
         let chunk = &data[offset..end];
-        // Wait for connection just in case
         cdc.wait_connection().await;
-        // Try writing
         match cdc.write_packet(chunk).await {
             Ok(_) => offset = end,
-            Err(e) => {
-                // Handle or retry error (e.g., BufferOverflow)
-                // Could add delay before retry, or return error to caller
-                return Err(e);
-            }
+            Err(e) => return Err(e),
         }
     }
     Ok(())
@@ -79,11 +77,11 @@ async fn main(spawner: Spawner) {
     let mut cdc = CdcAcmClass::new(&mut usb_builder, STATE.init(State::new()), 64);
     let usb = usb_builder.build();
 
-    spawner.spawn(usb_task(usb)).unwrap();
+    spawner.spawn(usb_task(usb).unwrap());
 
     // ADC setup
     let mut adc = Adc::new(p.ADC, IrqsADC, Config::default());
-    let mut dma = p.DMA_CH0;
+    let mut dma = dma::Channel::new(p.DMA_CH0, IrqsDMA);
     let mut p26 = Channel::new_pin(p.PIN_26, Pull::None);
 
     const BUFFER_SIZE: usize = 1024;
@@ -95,22 +93,21 @@ async fn main(spawner: Spawner) {
         loop {
             let mut audio_buffer: [u16; BUFFER_SIZE] = [0_u16; BUFFER_SIZE];
             if let Ok(_) = adc
-                .read_many(&mut p26, &mut audio_buffer, ADC_DIV, dma.reborrow())
+                .read_many(&mut p26, &mut audio_buffer, ADC_DIV, &mut dma)
                 .await
             {
                 let audio_bytes: &[u8] = bytemuck::cast_slice(&audio_buffer);
                 info!("{}", &audio_bytes);
-                // Write audio bytes to USB CDC ACM
                 let result = write_cdc_chunked(&mut cdc, audio_bytes).await;
                 match result {
                     Ok(_) => {}
                     Err(e) => {
                         info!("USB write error: {:?}", e);
-                        break; // If USB write fails, break and wait for next connection
+                        break;
                     }
                 }
             } else {
-                break; // If ADC fails, break and wait for next connection
+                break;
             }
         }
     }

--- a/src/common/usb.rs
+++ b/src/common/usb.rs
@@ -45,7 +45,7 @@ pub async fn write_cdc_chunked(
 pub fn init_usb(usb: Peri<'static, USB>) -> embassy_usb::Builder<'static, Driver<'static, USB>> {
     let driver = Driver::new(usb, Irqs);
 
-    let mut usb_builder = embassy_usb::Builder::new(
+    let usb_builder = embassy_usb::Builder::new(
         driver,
         {
             let mut cfg = embassy_usb::Config::new(0xc0de, 0xcafe);

--- a/src/common/wifi.rs
+++ b/src/common/wifi.rs
@@ -12,7 +12,7 @@ use embassy_rp::clocks::RoscRng;
 use embassy_rp::gpio::{Level, Output};
 use embassy_rp::Peri;
 use embassy_rp::dma;
-use embassy_rp::peripherals::{DMA_CH0, PIN_23, PIN_24, PIN_25, PIN_29, PIO0};
+use embassy_rp::peripherals::{DMA_CH0, DMA_CH1, PIN_23, PIN_24, PIN_25, PIN_29, PIO0};
 use embassy_rp::pio::{InterruptHandler, Pio};
 use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, mutex::Mutex};
 use embassy_time::{Duration, Timer};
@@ -21,9 +21,12 @@ use static_cell::StaticCell;
 
 pub const WEB_TASK_POOL_SIZE: usize = 12;
 
-bind_interrupts!(struct Irqs {
+// Shared interrupt bindings for the whole project. DMA_IRQ_0 is used by both
+// the WiFi SPI (DMA_CH0) and the ADC audio path (DMA_CH1); only one handler
+// for DMA_IRQ_0 may exist per binary, so we centralise it here.
+bind_interrupts!(pub struct Irqs {
     PIO0_IRQ_0 => InterruptHandler<PIO0>;
-    DMA_IRQ_0 => dma::InterruptHandler<DMA_CH0>;
+    DMA_IRQ_0 => dma::InterruptHandler<DMA_CH0>, dma::InterruptHandler<DMA_CH1>;
 });
 
 #[embassy_executor::task]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use cyw43_pio::{DEFAULT_CLOCK_DIVIDER, PioSpi};
 use defmt::*;
 use embassy_executor::Spawner;
 use embassy_rp::bind_interrupts;
+use embassy_rp::dma;
 use embassy_rp::gpio::{Level, Output};
 use embassy_rp::peripherals::{DMA_CH0, PIO0};
 use embassy_rp::pio::{InterruptHandler, Pio};
@@ -14,11 +15,12 @@ use {defmt_rtt as _, panic_probe as _};
 
 bind_interrupts!(struct Irqs {
     PIO0_IRQ_0 => InterruptHandler<PIO0>;
+    DMA_IRQ_0 => dma::InterruptHandler<DMA_CH0>;
 });
 
 #[embassy_executor::task]
 async fn cyw43_task(
-    runner: cyw43::Runner<'static, Output<'static>, PioSpi<'static, PIO0, 0, DMA_CH0>>,
+    runner: cyw43::Runner<'static, cyw43::SpiBus<Output<'static>, PioSpi<'static, PIO0, 0>>>,
 ) -> ! {
     runner.run().await
 }
@@ -26,15 +28,9 @@ async fn cyw43_task(
 #[embassy_executor::main]
 async fn main(spawner: Spawner) {
     let p = embassy_rp::init(Default::default());
-    let fw = include_bytes!("../cyw43-firmware/43439A0.bin");
+    let fw = cyw43::aligned_bytes!("../cyw43-firmware/43439A0.bin");
+    let nvram = cyw43::aligned_bytes!("../cyw43-firmware/nvram_rp2040.bin");
     let clm = include_bytes!("../cyw43-firmware/43439A0_clm.bin");
-
-    // To make flashing faster for development, you may want to flash the firmwares independently
-    // at hardcoded addresses, instead of baking them into the program with `include_bytes!`:
-    //     probe-rs download 43439A0.bin --binary-format bin --chip RP2040 --base-address 0x10100000
-    //     probe-rs download 43439A0_clm.bin --binary-format bin --chip RP2040 --base-address 0x10140000
-    //let fw = unsafe { core::slice::from_raw_parts(0x10100000 as *const u8, 230321) };
-    //let clm = unsafe { core::slice::from_raw_parts(0x10140000 as *const u8, 4752) };
 
     let pwr = Output::new(p.PIN_23, Level::Low);
     let cs = Output::new(p.PIN_25, Level::High);
@@ -47,13 +43,13 @@ async fn main(spawner: Spawner) {
         cs,
         p.PIN_24,
         p.PIN_29,
-        p.DMA_CH0,
+        dma::Channel::new(p.DMA_CH0, Irqs),
     );
 
     static STATE: StaticCell<cyw43::State> = StaticCell::new();
     let state = STATE.init(cyw43::State::new());
-    let (_net_device, mut control, runner) = cyw43::new(state, pwr, spi, fw).await;
-    unwrap!(spawner.spawn(cyw43_task(runner)));
+    let (_net_device, mut control, runner) = cyw43::new(state, pwr, spi, fw, nvram).await;
+    spawner.spawn(cyw43_task(runner).unwrap());
 
     control.init(clm).await;
     control


### PR DESCRIPTION
## Summary

- **cyw43 API**: `Runner` now takes one generic (`SpiBus` wrapper); `cyw43::new()` requires a 5th `nvram` arg; firmware must use `cyw43::aligned_bytes!()` instead of `include_bytes!()`
- **DMA IRQ consolidation**: All `DMA_IRQ_0` bindings centralized in `wifi::Irqs` (covering both `DMA_CH0` and `DMA_CH1`) to prevent multiply-defined `#[no_mangle]` symbol errors under LTO. Binaries that need DMA (`audio_udp`, `audio_usb`) import `wifi::Irqs` instead of defining their own `bind_interrupts!`
- **Task spawn**: Task invocations now return `Result<SpawnToken>`; changed to `spawner.spawn(task(...).unwrap())` pattern throughout
- **StaticCell**: Replaced `make_static!()` calls (which caused borrow-check cycles in `#[embassy_executor::main]`) with explicit `static StaticCell<T>` + `.init()` pattern

## Test plan

- [ ] `cargo build --target thumbv6m-none-eabi --bins` compiles all binaries with zero errors
- [ ] Only minor warnings remain (unused import in `audio_usb`, unknown lint in `server`)
- [ ] Flash and smoke-test individual bins on hardware

---
_Generated by [Claude Code](https://claude.ai/code/session_017MP4hbbrcDJ8JXW76YBivA)_