### PR TITLE
Fix duplicate Irqs/WIFI_CORE definitions causing build errors

### DIFF
--- a/src/bin/audio_udp.rs
+++ b/src/bin/audio_udp.rs
@@ -19,16 +19,13 @@ use embassy_time::{Duration, Instant, Timer};
 use pinot_voir::common::adc_microphone::adc_task;
 use pinot_voir::common::audio::{AudioBlock, BUFFER_SIZE};
 use pinot_voir::common::shared_functions::EnvironmentVariables;
-use pinot_voir::common::wifi::{EmbassyPicoWifiCore, Irqs, SharedEmbassyWifiPicoCore};
+use pinot_voir::common::wifi::{EmbassyPicoWifiCore, SharedEmbassyWifiPicoCore};
 use static_cell::StaticCell;
 
 bind_interrupts!(struct Irqs {
     DMA_IRQ_0 => dma::InterruptHandler<DMA_CH0>, dma::InterruptHandler<DMA_CH1>, dma::InterruptHandler<DMA_CH2>;
 });
 
-static WIFI_CORE: StaticCell<
-    Mutex<CriticalSectionRawMutex, pinot_voir::common::wifi::EmbassyPicoWifiCore>,
-> = StaticCell::new();
 use {defmt_rtt as _, panic_probe as _};
 
 // ---------- Executors / Core stacks ----------

--- a/src/bin/audio_usb.rs
+++ b/src/bin/audio_usb.rs
@@ -13,7 +13,6 @@ use embassy_usb::class::cdc_acm::{CdcAcmClass, State as CdcState};
 use pinot_voir::common::adc_microphone::adc_task;
 use pinot_voir::common::audio::AudioBlock;
 use pinot_voir::common::usb::{cdc_tx_task, init_usb, usb_device_task};
-use pinot_voir::common::wifi::Irqs;
 use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};
 

--- a/src/bin/uart_log.rs
+++ b/src/bin/uart_log.rs
@@ -24,9 +24,6 @@ bind_interrupts!(struct Irqs {
 bind_interrupts!(struct IrqsADC {
     ADC_IRQ_FIFO => ADCInterruptHandler;
 });
-bind_interrupts!(struct IrqsDMA {
-    DMA_IRQ_0 => dma::InterruptHandler<DMA_CH0>;
-});
 
 async fn write_cdc_chunked<'a>(
     cdc: &mut CdcAcmClass<'static, Driver<'static, USB>>,


### PR DESCRIPTION
- audio_udp.rs: remove Irqs import from wifi (conflicts with local bind_interrupts!), remove duplicate WIFI_CORE static
- audio_usb.rs: remove unused wifi::Irqs import (no wifi in this binary)
- uart_log.rs: remove IrqsDMA block (DMA_IRQ_0 already bound in Irqs)
